### PR TITLE
allow variable number of arguments to 'emit' function

### DIFF
--- a/ngSocket.js
+++ b/ngSocket.js
@@ -101,9 +101,12 @@
         socket.removeAllListeners(name);
       }
 
-      function emit(name, data, callback) {
+      function emit(name) {
         initializeSocket();
-        socket.emit(name, data, angularCallback(callback));
+        var callback = arguments[arguments.length -1];
+        if ("function" === typeof callback)
+          arguments[arguments.length -1] = angularCallback(callback);
+        socket.emit.apply(socket, arguments);
       }
       
       function getSocket() {


### PR DESCRIPTION
Current implementation does not respect `emit` function prototype. There are cases where one does not want to send data nor use a callback function, etc.
This change allows variable number of arguments to the `emit` function.
Note that this is not a breaking change as if arguments `name, data, callback` are given, they are still processed the same way they used to.
